### PR TITLE
fix abstract method override error

### DIFF
--- a/android/src/main/java/com/rctbattery/BatteryManagerPackage.java
+++ b/android/src/main/java/com/rctbattery/BatteryManagerPackage.java
@@ -1,6 +1,7 @@
 package com.rctbattery;
 
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -10,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class BatteryManagerPackage implements ReactPackage {
+
+  @Override public List<Class<? extends JavaScriptModule>> createJSModules() { return Collections.emptyList(); }
 
   @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {


### PR DESCRIPTION
#What does this PR do?
Fixes error with BatteryManagerPackage overriding abstract method createJSModules() in ReactPackage